### PR TITLE
Simplify Boxer and Unboxer implementations

### DIFF
--- a/boxstream/box.go
+++ b/boxstream/box.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"log"
 
 	"golang.org/x/crypto/nacl/secretbox"
 )
@@ -34,27 +33,67 @@ const (
 	MaxSegmentSize = 4 * 1024
 )
 
-var final [18]byte
+var goodbye [18]byte
 
 // Boxer encrypts everything that is written to it
 type Boxer struct {
-	input  *io.PipeReader
-	output io.WriteCloser
+	w      io.Writer
 	secret *[32]byte
 	nonce  *[24]byte
 }
 
+// writeMessage writes a boxstream packet to the underlying writer.
+func (b *Boxer) writeMessage(msg []byte) error {
+	if len(msg) > MaxSegmentSize {
+		panic("message exceeds maximum segment size")
+	}
+	headerNonce := *b.nonce
+	increment(b.nonce)
+	bodyNonce := *b.nonce
+	increment(b.nonce)
+
+	// construct body box
+	bodyBox := secretbox.Seal(nil, msg, &bodyNonce, b.secret)
+	bodyMAC, body := bodyBox[:secretbox.Overhead], bodyBox[secretbox.Overhead:]
+
+	// construct header box
+	header := make([]byte, 2+secretbox.Overhead)
+	binary.BigEndian.PutUint16(header[:2], uint16(len(msg)))
+	copy(header[2:], bodyMAC)
+	headerBox := secretbox.Seal(nil, header, &headerNonce, b.secret)
+
+	// write header + body
+	if _, err := b.w.Write(headerBox); err != nil {
+		return err
+	}
+	_, err := b.w.Write(body)
+	return err
+}
+
+// Write implements io.Writer.
+func (b *Boxer) Write(p []byte) (int, error) {
+	buf := bytes.NewBuffer(p)
+	for buf.Len() > 0 {
+		if err := b.writeMessage(buf.Next(MaxSegmentSize)); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+// Close implements io.Closer. It writes the 'goodbye' protocol message to the underlying writer.
+func (b *Boxer) Close() error {
+	_, err := b.w.Write(secretbox.Seal(nil, goodbye[:], b.nonce, b.secret))
+	return err
+}
+
 // NewBoxer returns a Boxer wich encrypts everything that is written to the passed writer
-func NewBoxer(wc io.WriteCloser, nonce *[24]byte, secret *[32]byte) io.WriteCloser {
-	pr, pw := io.Pipe()
-	b := &Boxer{
-		input:  pr,
-		output: wc,
+func NewBoxer(w io.Writer, nonce *[24]byte, secret *[32]byte) io.WriteCloser {
+	return &Boxer{
+		w:      w,
 		secret: secret,
 		nonce:  nonce,
 	}
-	go b.loop()
-	return pw
 }
 
 func increment(b *[24]byte) *[24]byte {
@@ -70,67 +109,4 @@ func increment(b *[24]byte) *[24]byte {
 	b[i] = b[i] + 1
 
 	return b
-}
-
-func (b *Boxer) loop() {
-	var running = true
-	var eof = false
-	var nonce1, nonce2 [24]byte
-
-	check := func(err error) {
-		if err != nil {
-			running = false
-			if err2 := b.input.CloseWithError(err); err2 != nil {
-				log.Print("Boxer: pipe CloseWithErr failed: ", err)
-			}
-		}
-	}
-
-	defer func() {
-		if err := b.output.Close(); err != nil {
-			log.Print("Boxer: output writer close failed: ", err)
-		}
-	}()
-
-	// prepare nonces
-	copy(nonce1[:], b.nonce[:])
-	copy(nonce2[:], b.nonce[:])
-
-	for running {
-
-		msg := make([]byte, MaxSegmentSize)
-		n, err := io.ReadAtLeast(b.input, msg, 1)
-		if err == io.EOF {
-			eof = true
-			running = false
-		} else {
-			check(err)
-		}
-		msg = msg[:n]
-
-		// buffer for box of current
-		boxed := secretbox.Seal(nil, msg, increment(&nonce2), b.secret)
-		// define and populate header
-		var hdrPlain = bytes.NewBuffer(nil)
-		err = binary.Write(hdrPlain, binary.BigEndian, uint16(len(msg)))
-		check(err)
-
-		// slice mac from box
-		hdrPlain.Write(boxed[:16]) // ???
-
-		if eof {
-			hdrPlain.Reset()
-			hdrPlain.Write(final[:])
-		}
-		hdrBox := secretbox.Seal(nil, hdrPlain.Bytes(), &nonce1, b.secret)
-
-		increment(increment(&nonce1))
-		increment(&nonce2)
-
-		_, err = io.Copy(b.output, bytes.NewReader(hdrBox))
-		check(err)
-
-		_, err = io.Copy(b.output, bytes.NewReader(boxed[secretbox.Overhead:]))
-		check(err)
-	}
 }

--- a/boxstream/unbox.go
+++ b/boxstream/unbox.go
@@ -28,75 +28,66 @@ import (
 
 // Unboxer decrypts everything that is read from it
 type Unboxer struct {
-	input  io.Reader
-	output *io.PipeWriter
+	r      io.Reader
+	msg    []byte
 	secret *[32]byte
 	nonce  *[24]byte
 }
 
-// NewUnboxer wraps the passed input Reader into an Unboxer
-func NewUnboxer(input io.Reader, nonce *[24]byte, secret *[32]byte) io.ReadCloser {
-	pr, pw := io.Pipe()
-	unboxer := &Unboxer{
-		input:  input,
-		output: pw,
-		secret: secret,
-		nonce:  nonce,
+// readNextBox reads the next message from the underlying stream.
+func (u *Unboxer) readNextBox() error {
+	headerNonce := *u.nonce
+	increment(u.nonce)
+	bodyNonce := *u.nonce
+	increment(u.nonce)
+
+	// read and unbox header
+	headerBox := make([]byte, 2+secretbox.Overhead+secretbox.Overhead)
+	if _, err := io.ReadFull(u.r, headerBox); err != nil {
+		return err
 	}
-	go unboxer.readerloop()
-	return pr
+	header, ok := secretbox.Open(nil, headerBox, &headerNonce, u.secret)
+	if !ok {
+		return errors.New("invalid header box")
+	}
+
+	// zero header indicates termination
+	if bytes.Equal(header, goodbye[:]) {
+		return io.EOF
+	}
+
+	// read and unbox body
+	bodyLen := binary.BigEndian.Uint16(header[:2])
+	bodyBox := make([]byte, int(bodyLen)+secretbox.Overhead)
+	if _, err := io.ReadFull(u.r, bodyBox[secretbox.Overhead:]); err != nil {
+		return err
+	}
+	// prepend with MAC from header
+	copy(bodyBox, header[2:])
+	u.msg, ok = secretbox.Open(u.msg[:0], bodyBox, &bodyNonce, u.secret)
+	if !ok {
+		return errors.New("invalid body box")
+	}
+	return nil
 }
 
-func (u *Unboxer) readerloop() {
-	hdrBox := make([]byte, HeaderLength)
-	hdr := make([]byte, 0, HeaderLength-secretbox.Overhead)
-	var ok bool
-	for {
-		hdr = hdr[:0]
-		_, err := io.ReadFull(u.input, hdrBox)
-		if err != nil {
-			u.output.CloseWithError(err)
-			return
+// Read implements io.Reader.
+func (u *Unboxer) Read(p []byte) (int, error) {
+	if len(u.msg) == 0 {
+		if err := u.readNextBox(); err != nil {
+			return 0, err
 		}
+	}
+	n := copy(p, u.msg)
+	u.msg = u.msg[n:]
+	return n, nil
+}
 
-		hdr, ok = secretbox.Open(hdr, hdrBox, u.nonce, u.secret)
-		if !ok {
-			u.output.CloseWithError(errors.New("boxstream: error opening header box"))
-			return
-		}
-
-		// zero header indicates termination
-		if bytes.Equal(final[:], hdr) {
-			u.output.Close()
-			return
-		}
-
-		n := binary.BigEndian.Uint16(hdr[:2])
-
-		buf := make([]byte, n+secretbox.Overhead)
-
-		tag := hdr[2:] // len(tag) == seceretbox.Overhead
-
-		copy(buf[:secretbox.Overhead], tag)
-
-		_, err = io.ReadFull(u.input, buf[len(tag):])
-		if err != nil {
-			u.output.CloseWithError(err)
-			return
-		}
-
-		out := make([]byte, 0, n)
-		out, ok = secretbox.Open(out, buf, increment(u.nonce), u.secret)
-		if !ok {
-			u.output.CloseWithError(errors.New("boxstream: error opening body box"))
-			return
-		}
-
-		_, err = io.Copy(u.output, bytes.NewReader(out))
-		if err != nil {
-			u.output.CloseWithError(err)
-			return
-		}
-		increment(u.nonce)
+// NewUnboxer wraps the passed Reader into an Unboxer.
+func NewUnboxer(r io.Reader, nonce *[24]byte, secret *[32]byte) io.Reader {
+	return &Unboxer{
+		r:      r,
+		secret: secret,
+		nonce:  nonce,
 	}
 }

--- a/client.go
+++ b/client.go
@@ -58,7 +58,7 @@ func (c *Client) ConnWrapper(pubKey [ed25519.PublicKeySize]byte) netwrap.ConnWra
 		deKey, deNonce := state.GetBoxstreamDecKeys()
 
 		boxed := &Conn{
-			ReadCloser:  boxstream.NewUnboxer(conn, &deNonce, &deKey),
+			Reader:      boxstream.NewUnboxer(conn, &deNonce, &deKey),
 			WriteCloser: boxstream.NewBoxer(conn, &enNonce, &enKey),
 			conn:        conn,
 			local:       c.kp.Public[:],

--- a/conn.go
+++ b/conn.go
@@ -48,7 +48,7 @@ func (a Addr) String() string {
 
 // Conn is a boxstream wrapped net.Conn
 type Conn struct {
-	io.ReadCloser
+	io.Reader
 	io.WriteCloser
 	conn net.Conn
 
@@ -59,24 +59,21 @@ type Conn struct {
 // Close closes the underlying net.Conn
 func (conn *Conn) Close() error {
 	werr := conn.WriteCloser.Close()
-	rerr := conn.ReadCloser.Close()
+	cerr := conn.conn.Close()
 
 	werr = errors.Wrap(werr, "boxstream: error closing boxer")
-	rerr = errors.Wrap(rerr, "boxstream: error closing unboxer")
+	cerr = errors.Wrap(cerr, "boxstream: error closing conn")
 
-	// TODO: just to be double sure the FD is closed if the piping (un)boxes mess this up?
-	// defer conn.conn.Close()
-
-	if werr != nil && rerr != nil {
-		return errors.Wrap(multierror.Append(werr, rerr), "error closing both boxstream boxer and unboxer")
+	if werr != nil && cerr != nil {
+		return errors.Wrap(multierror.Append(werr, cerr), "error closing both boxer and conn")
 	}
 
 	if werr != nil {
 		return werr
 	}
 
-	if rerr != nil {
-		return rerr
+	if cerr != nil {
+		return cerr
 	}
 
 	return nil

--- a/server.go
+++ b/server.go
@@ -61,7 +61,7 @@ func (s *Server) ConnWrapper() netwrap.ConnWrapper {
 
 		remote := state.Remote()
 		boxed := &Conn{
-			ReadCloser:  boxstream.NewUnboxer(conn, &deNonce, &deKey),
+			Reader:      boxstream.NewUnboxer(conn, &deNonce, &deKey),
 			WriteCloser: boxstream.NewBoxer(conn, &enNonce, &enKey),
 			conn:        conn,
 			local:       s.keyPair.Public[:],


### PR DESCRIPTION
Previously, `Boxer` and `Unboxer` used an `io.Pipe` and a goroutine to wrap the underlying stream. This PR refactors those types to implement `io.Reader` and `io.Writer` directly. As a side effect, `Unboxer` no longer needs to be a `ReadCloser`.

Personally I would recommend switching to explicit `WriteMessage` and `ReadMessage` methods on `Boxer` and `Unboxer`, and letting `Conn` handle the streaming abstraction. I can implement this in a follow-up PR if you'd like.