### PR TITLE
Punt streaming abstractions to Conn

### DIFF
--- a/boxstream/box_test.go
+++ b/boxstream/box_test.go
@@ -42,25 +42,20 @@ func TestBox(t *testing.T) {
 	cErrc := make(chan error)
 	checkC := mkCheckOnce(cErrc)
 	go func() {
-		_, err := bw.Write([]byte{0, 1, 2, 3, 4, 5})
+		err := bw.WriteMessage([]byte{0, 1, 2, 3, 4, 5})
 		checkW(err)
 
-		err = bw.Close()
+		err = bw.WriteGoodbye()
 		checkC(err)
 	}()
 
-	buf := make([]byte, 10)
-
-	n, err := br.Read(buf[:6])
+	rx, err := br.ReadMessage()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if e, ok := <-wErrc; ok {
 		t.Fatal(e)
 	}
-
-	rx := buf[:n]
-
 	if len(rx) != 6 {
 		t.Error("rx len wrong")
 	}
@@ -71,12 +66,10 @@ func TestBox(t *testing.T) {
 		}
 	}
 
-	var eof = make([]byte, 10)
-	n, err = br.Read(eof)
+	rx, err = br.ReadMessage()
 	if err != io.EOF {
 		t.Fatal(err)
-	}
-	if n != 0 {
+	} else if len(rx) != 0 {
 		t.Errorf("more data?")
 	}
 

--- a/boxstream/unbox.go
+++ b/boxstream/unbox.go
@@ -14,62 +14,55 @@ import (
 // Unboxer decrypts everything that is read from it
 type Unboxer struct {
 	r      io.Reader
-	msg    []byte
+	buf    [MaxSegmentSize + secretbox.Overhead]byte
 	secret *[32]byte
 	nonce  *[24]byte
 }
 
-// readNextBox reads the next message from the underlying stream.
-func (u *Unboxer) readNextBox() error {
+// ReadMessage reads the next message from the underlying stream. If the next
+// message was a 'goodbye', it returns io.EOF.
+func (u *Unboxer) ReadMessage() ([]byte, error) {
 	headerNonce := *u.nonce
 	increment(u.nonce)
 	bodyNonce := *u.nonce
 	increment(u.nonce)
 
 	// read and unbox header
-	headerBox := make([]byte, 2+secretbox.Overhead+secretbox.Overhead)
+	headerBox := u.buf[:HeaderLength]
 	if _, err := io.ReadFull(u.r, headerBox); err != nil {
-		return err
+		return nil, err
 	}
-	header, ok := secretbox.Open(nil, headerBox, &headerNonce, u.secret)
+	headerBuf := make([]byte, 0, 18)
+	header, ok := secretbox.Open(headerBuf, headerBox, &headerNonce, u.secret)
 	if !ok {
-		return errors.New("invalid header box")
+		return nil, errors.New("invalid header box")
 	}
 
 	// zero header indicates termination
 	if bytes.Equal(header, goodbye[:]) {
-		return io.EOF
+		return nil, io.EOF
 	}
 
 	// read and unbox body
 	bodyLen := binary.BigEndian.Uint16(header[:2])
-	bodyBox := make([]byte, int(bodyLen)+secretbox.Overhead)
+	if bodyLen > MaxSegmentSize {
+		return nil, errors.New("message exceeds maximum segment size")
+	}
+	bodyBox := u.buf[:bodyLen+secretbox.Overhead]
 	if _, err := io.ReadFull(u.r, bodyBox[secretbox.Overhead:]); err != nil {
-		return err
+		return nil, err
 	}
 	// prepend with MAC from header
 	copy(bodyBox, header[2:])
-	u.msg, ok = secretbox.Open(u.msg[:0], bodyBox, &bodyNonce, u.secret)
+	msg, ok := secretbox.Open(nil, bodyBox, &bodyNonce, u.secret)
 	if !ok {
-		return errors.New("invalid body box")
+		return nil, errors.New("invalid body box")
 	}
-	return nil
-}
-
-// Read implements io.Reader.
-func (u *Unboxer) Read(p []byte) (int, error) {
-	if len(u.msg) == 0 {
-		if err := u.readNextBox(); err != nil {
-			return 0, err
-		}
-	}
-	n := copy(p, u.msg)
-	u.msg = u.msg[n:]
-	return n, nil
+	return msg, nil
 }
 
 // NewUnboxer wraps the passed Reader into an Unboxer.
-func NewUnboxer(r io.Reader, nonce *[24]byte, secret *[32]byte) io.Reader {
+func NewUnboxer(r io.Reader, nonce *[24]byte, secret *[32]byte) *Unboxer {
 	return &Unboxer{
 		r:      r,
 		secret: secret,

--- a/client.go
+++ b/client.go
@@ -43,11 +43,11 @@ func (c *Client) ConnWrapper(pubKey [ed25519.PublicKeySize]byte) netwrap.ConnWra
 		deKey, deNonce := state.GetBoxstreamDecKeys()
 
 		boxed := &Conn{
-			Reader:      boxstream.NewUnboxer(conn, &deNonce, &deKey),
-			WriteCloser: boxstream.NewBoxer(conn, &enNonce, &enKey),
-			conn:        conn,
-			local:       c.kp.Public[:],
-			remote:      state.Remote(),
+			boxer:   boxstream.NewBoxer(conn, &enNonce, &enKey),
+			unboxer: boxstream.NewUnboxer(conn, &deNonce, &deKey),
+			conn:    conn,
+			local:   c.kp.Public[:],
+			remote:  state.Remote(),
 		}
 
 		return boxed, nil

--- a/server.go
+++ b/server.go
@@ -46,11 +46,11 @@ func (s *Server) ConnWrapper() netwrap.ConnWrapper {
 
 		remote := state.Remote()
 		boxed := &Conn{
-			Reader:      boxstream.NewUnboxer(conn, &deNonce, &deKey),
-			WriteCloser: boxstream.NewBoxer(conn, &enNonce, &enKey),
-			conn:        conn,
-			local:       s.keyPair.Public[:],
-			remote:      remote[:],
+			boxer:   boxstream.NewBoxer(conn, &enNonce, &enKey),
+			unboxer: boxstream.NewUnboxer(conn, &deNonce, &deKey),
+			conn:    conn,
+			local:   s.keyPair.Public[:],
+			remote:  remote[:],
 		}
 
 		return boxed, nil


### PR DESCRIPTION
This implements the design I suggested in #11.

`boxer` and `unboxer` no longer implement `io.Writer` and `io.Reader`; instead, they provide `WriteMessage` and `ReadMessage` methods that reflect the message-based design of the protocol. The implementations of `io.Writer` and `io.Reader` have been pushed up the stack to the `Conn` type. This is analogous to how `net.UDPConn`  provides a streaming API for the packet-based UDP protocol.

This PR is more subjective than my previous two, so feel free to reject if you disagree with my sensibilities. 😅 